### PR TITLE
Fixes 'OEGridView' post_install hook can't convert String into Integer error.

### DIFF
--- a/OEGridView/1.0.0/OEGridView.podspec
+++ b/OEGridView/1.0.0/OEGridView.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
     project = target_installer.project
     project.objects.each do |obj|
       if obj.isa.to_s == "PBXBuildFile"
-        fileRef = obj.attributes["fileRef"]
-        file_name = project.objects[fileRef].pathname.basename.to_s
+        fileRef = obj.to_hash["fileRef"]
+        file_name = project.objects_by_uuid[fileRef].pathname.basename.to_s
         if ["NSColor+OEAdditions.m"].include?(file_name)
           obj.settings.delete('COMPILER_FLAGS')
         end


### PR DESCRIPTION
It seems that the implementation of xcodeproj in CocoaPods has changed recently and the attribute hash has to be accessed differently, hence the "can't convert String into Integer" error. Should fix issue #2.
