### PR TITLE
make NSColor extentsions as subspec to fix post_install hook error

### DIFF
--- a/OEGridView/1.0.0/OEGridView.podspec
+++ b/OEGridView/1.0.0/OEGridView.podspec
@@ -9,16 +9,11 @@ Pod::Spec.new do |s|
 	s.framework = 'QuartzCore'
 	s.requires_arc = true
 
-  def s.post_install(target_installer)
-    project = target_installer.project
-    project.objects.each do |obj|
-      if obj.isa.to_s == "PBXBuildFile"
-        fileRef = obj.to_hash["fileRef"]
-        file_name = project.objects_by_uuid[fileRef].pathname.basename.to_s
-        if ["NSColor+OEAdditions.m"].include?(file_name)
-          obj.settings.delete('COMPILER_FLAGS')
-        end
-      end
+    non_arc_files = 'NSColor+OEAdditions.{h,m}'
+    s.exclude_files = non_arc_files
+    
+    s.subspec 'no-arc' do |sna|
+      sna.requires_arc = false
+      sna.source_files = non_arc_files
     end
-  end
 end

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ All the custom podspecs needed to compile Sonora
 
 ### Adding the podspec repo to CocoaPods
 
+#####~~pod repo add Sonora-Podspecs git://github.com/sonoramac/Podspecs.git master~~
+
 ```
-pod repo add Sonora-Podspecs git://github.com/sonoramac/Podspecs.git master
+pod repo add Sonora-Podspecs https://github.com/CrazyCatcher/Podspecs.git master
 ```
 Adding this podspec repository to CocoaPods will allow Sonora's Podfile to access the custom podspecs required to compile.
 


### PR DESCRIPTION
It seems that the post_install hook error reappear now. **my CocoaPods'version is 0.29.0**.  Don't know the subspec is the right solutions or not, it work just fine when I test it.